### PR TITLE
Simplify mnp setup and runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,12 +64,6 @@ target_link_libraries(
 )
 
 install(
-    FILES .mnp.ini
-    DESTINATION ~
-    COMPONENT config
-)
-
-install(
     TARGETS mnp
     DESTINATION bin
     COMPONENT binaries

--- a/README.md
+++ b/README.md
@@ -47,36 +47,32 @@ sudo make install
 
 gpg_key : [d4ndo@proton.me](https://github.com/d4ndox/mnp/blob/master/doc/d4ndo%40proton.me.pub).
 
-## How to Run mnp?
+## How to Set UP mnp?
 
 For details see the wiki [Getting Started](https://github.com/d4ndox/mnp/wiki/Getting-started).
 
-1. Initialise mnp:
+1. Create the configuration:
+```bash
+./setup.sh
+```
+
+2. Start monerod and monero-wallet-rpc:
+```bash
+./start.sh
+````
+
+3. Initialise mnp:
 ```bash
 mnp init
 ```
+## Usage
 
-2. Start `monerod`:
+Show balance
 ```bash
-monerod --detach
+mnp balance
 ```
 
-3. Start `monero-wallet-rpc` with configuration:
-```bash
-monero-wallet-rpc --config-file notify-mnp.cfg
-```
-
-`notify-mnp.cfg` example:
-```cfg
-rpc-bind-ip=127.0.0.1
-rpc-bind-port=18084
-rpc-login=username:password
-wallet-file=mywallet
-password=mywalletpassword
-tx-notify=/usr/local/bin/mnp --confirmation 1 %s
-```
-
-## How to Set Up a Payment?
+### How to Set Up a Payment?
 
 For details see the wiki [Setup a Payment](https://github.com/d4ndox/mnp/wiki/Setup-a-payment).
 
@@ -85,7 +81,7 @@ Create a new subaddress:
 mnp payment new --amount 650000
 ```
 
-## How to Monitor /tmp/wallet/transactions?
+### How to Monitor /tmp/mywallet/transactions?
 
 For details see the wiki [Monitor a Payment](https://github.com/d4ndox/mnp/wiki/Monitor-a-payment).
 
@@ -95,6 +91,11 @@ find /tmp/mywallet/transactions -type p -exec cat {} \;
 ```
 
 ## Close mnp [Optional]
+
+Stop monero-wallet-rpc:
+```bash
+./stop.sh
+```
 
 Remove the work directory:
 ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -22,6 +22,8 @@ wallet_rpc_port=""
 rpc_password=""
 mnp_bin="mnp"
 missing_runtime=0
+confirmations=0
+tx_notify_args="--notify-at 1"
 
 usage()
 {
@@ -234,6 +236,36 @@ select_network()
     echo
 }
 
+read_confirmations()
+{
+    local input
+
+    echo "Transaction notification"
+    echo
+
+    while true; do
+        read -r -p "Confirmations [0]: " input
+        input="${input:-0}"
+
+        if [[ "$input" =~ ^[0-9]+$ ]]; then
+            confirmations="$input"
+            break
+        fi
+
+        warn "Confirmations must be a non-negative integer"
+    done
+
+    if ((confirmations == 0)); then
+        tx_notify_args="--notify-at 1"
+        ok "Transaction notification: txpool"
+    else
+        tx_notify_args="--notify-at 2 --confirmation ${confirmations}"
+        ok "Transaction notification: ${confirmations} confirmation(s)"
+    fi
+
+    echo
+}
+
 read_wallet_password()
 {
     local answer
@@ -345,7 +377,9 @@ write_wallet_rpc_config()
         printf 'rpc-login=mnp:%s\n' "$rpc_password"
         printf 'daemon-address=127.0.0.1:%s\n' "$daemon_port"
         echo "trusted-daemon=1"
-        printf 'tx-notify=%s %%s --confirmation 1\n' "$mnp_bin"
+        printf 'tx-notify=%s %s %%s\n' \
+            "$mnp_bin" \
+            "$tx_notify_args"
     } >"$WALLET_RPC_CONFIG"
 
     chmod 600 "$WALLET_RPC_CONFIG"
@@ -421,20 +455,27 @@ print_summary()
     echo
     echo "Configuration complete."
     echo
-    echo "  Wallet:     ${wallet_path}"
-    echo "  Network:    ${network}"
-    echo "  Daemon RPC: 127.0.0.1:${daemon_port}"
-    echo "  Wallet RPC: 127.0.0.1:${wallet_rpc_port}"
-    echo "  Config:     ${CONFIG_DIR}"
+    echo "  Wallet:        ${wallet_path}"
+    echo "  Network:       ${network}"
+    echo "  Daemon RPC:    127.0.0.1:${daemon_port}"
+    echo "  Wallet RPC:    127.0.0.1:${wallet_rpc_port}"
+
+    if ((confirmations == 0)); then
+        echo "  Notification:  txpool"
+    else
+        echo "  Confirmations: ${confirmations}"
+    fi
+
+    echo "  Config:        ${CONFIG_DIR}"
 
     if ((wallet_has_password)); then
-        echo "  Password:   ${WALLET_PASSWORD_FILE}"
+        echo "  Password:      ${WALLET_PASSWORD_FILE}"
     else
-        echo "  Password:   none"
+        echo "  Password:      none"
     fi
 
     echo
-    echo "  Legacy:     ${LEGACY_MNP_CONFIG} -> ${MNP_CONFIG}"
+    echo "  Legacy:        ${LEGACY_MNP_CONFIG} -> ${MNP_CONFIG}"
     echo
 
     if ((missing_runtime)); then
@@ -469,6 +510,7 @@ main()
     create_config_dir
     select_wallet
     select_network
+    read_confirmations
     read_wallet_password
     generate_rpc_password
     write_wallet_password

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,483 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/mnp"
+MNP_CONFIG="${CONFIG_DIR}/mnp.ini"
+MONEROD_CONFIG="${CONFIG_DIR}/monerod.conf"
+WALLET_RPC_CONFIG="${CONFIG_DIR}/monero-wallet-rpc.conf"
+WALLET_PASSWORD_FILE="${CONFIG_DIR}/wallet.password"
+RPC_PASSWORD_FILE="${CONFIG_DIR}/rpc.password"
+LEGACY_MNP_CONFIG="${HOME}/.mnp.ini"
+DEFAULT_WALLET_DIR="${HOME}/Monero/wallets"
+WORKDIR="/tmp/mywallet"
+
+wallet_path=""
+wallet_password=""
+wallet_has_password=0
+network=""
+daemon_port=""
+wallet_rpc_port=""
+rpc_password=""
+mnp_bin="mnp"
+missing_runtime=0
+
+usage()
+{
+    cat <<EOF
+Usage:
+  $0
+
+Creates the mnp configuration in:
+
+  ${CONFIG_DIR}
+
+No Monero process is started.
+EOF
+}
+
+ok()
+{
+    printf '[OK] %s\n' "$1"
+}
+
+warn()
+{
+    printf '[WARN] %s\n' "$1" >&2
+}
+
+error()
+{
+    printf '[ERROR] %s\n' "$1" >&2
+}
+
+check_optional_command()
+{
+    local command_name="$1"
+
+    if command -v "$command_name" >/dev/null 2>&1; then
+        ok "${command_name}: $(command -v "$command_name")"
+        return
+    fi
+
+    warn "${command_name} is not installed or not in PATH"
+    missing_runtime=1
+}
+
+check_dependencies()
+{
+    echo "Checking runtime dependencies..."
+
+    check_optional_command monerod
+    check_optional_command monero-wallet-rpc
+
+    if command -v mnp >/dev/null 2>&1; then
+        mnp_bin="$(command -v mnp)"
+        ok "mnp: ${mnp_bin}"
+    else
+        warn "mnp is not installed or not in PATH"
+        missing_runtime=1
+    fi
+
+    echo
+}
+
+create_config_dir()
+{
+    mkdir -p "$CONFIG_DIR"
+    chmod 700 "$CONFIG_DIR"
+
+    ok "Configuration directory: ${CONFIG_DIR}"
+    echo
+}
+
+find_wallets()
+{
+    local wallet
+    local -n result="$1"
+
+    result=()
+
+    if [ ! -d "$DEFAULT_WALLET_DIR" ]; then
+        return
+    fi
+
+    while IFS= read -r -d '' wallet; do
+        case "$wallet" in
+            *.keys|*.address.txt)
+                continue
+                ;;
+        esac
+
+        if [ -f "${wallet}.keys" ]; then
+            result+=("$wallet")
+        fi
+    done < <(
+        find "$DEFAULT_WALLET_DIR" \
+            -maxdepth 2 \
+            -type f \
+            -print0 2>/dev/null |
+            sort -z
+    )
+}
+
+read_wallet_path()
+{
+    while true; do
+        read -r -e -p "Wallet path: " wallet_path
+
+        wallet_path="${wallet_path/#\~/$HOME}"
+
+        if [ -f "$wallet_path" ] &&
+           [ -f "${wallet_path}.keys" ]; then
+            return
+        fi
+
+        warn "Wallet or '${wallet_path}.keys' not found"
+    done
+}
+
+select_wallet()
+{
+    local -a wallets
+    local selection
+    local i
+
+    find_wallets wallets
+
+    echo "Wallet"
+    echo
+
+    if ((${#wallets[@]} == 0)); then
+        warn "No wallets found in ${DEFAULT_WALLET_DIR}"
+        read_wallet_path
+    else
+        for ((i = 0; i < ${#wallets[@]}; i++)); do
+            printf '  %d) %s\n' "$((i + 1))" "${wallets[$i]}"
+        done
+
+        printf '  %d) Enter another path\n' "$((${#wallets[@]} + 1))"
+        echo
+
+        while true; do
+            read -r -p "Select wallet: " selection
+
+            if ! [[ "$selection" =~ ^[0-9]+$ ]]; then
+                warn "Please enter a number"
+                continue
+            fi
+
+            if ((selection >= 1 && selection <= ${#wallets[@]})); then
+                wallet_path="${wallets[$((selection - 1))]}"
+                break
+            fi
+
+            if ((selection == ${#wallets[@]} + 1)); then
+                read_wallet_path
+                break
+            fi
+
+            warn "Invalid selection"
+        done
+    fi
+
+    wallet_path="$(realpath "$wallet_path")"
+
+    ok "Wallet: ${wallet_path}"
+    echo
+}
+
+select_network()
+{
+    local selection
+
+    echo "Network"
+    echo
+    echo "  1) Mainnet"
+    echo "  2) Stagenet"
+    echo "  3) Testnet"
+    echo
+
+    while true; do
+        read -r -p "Select network [1]: " selection
+        selection="${selection:-1}"
+
+        case "$selection" in
+            1)
+                network="mainnet"
+                daemon_port="18081"
+                wallet_rpc_port="18084"
+                break
+                ;;
+            2)
+                network="stagenet"
+                daemon_port="38081"
+                wallet_rpc_port="38084"
+                break
+                ;;
+            3)
+                network="testnet"
+                daemon_port="28081"
+                wallet_rpc_port="28084"
+                break
+                ;;
+            *)
+                warn "Invalid selection"
+                ;;
+        esac
+    done
+
+    ok "Network: ${network}"
+    ok "Daemon RPC: 127.0.0.1:${daemon_port}"
+    ok "Wallet RPC: 127.0.0.1:${wallet_rpc_port}"
+    echo
+}
+
+read_wallet_password()
+{
+    local answer
+    local confirmation
+
+    echo "Wallet password"
+    echo
+
+    read -r -p "Is the wallet password protected? [y/N] " answer
+
+    case "$answer" in
+        y|Y|yes|YES)
+            wallet_has_password=1
+            ;;
+        *)
+            wallet_has_password=0
+            wallet_password=""
+            ok "Wallet password: none"
+            echo
+            return
+            ;;
+    esac
+
+    while true; do
+        IFS= read -r -s -p "Wallet password: " wallet_password
+        echo
+        IFS= read -r -s -p "Confirm password: " confirmation
+        echo
+
+        if [ "$wallet_password" = "$confirmation" ]; then
+            break
+        fi
+
+        warn "Passwords do not match"
+    done
+
+    ok "Wallet password configured"
+    echo
+}
+
+generate_rpc_password()
+{
+    rpc_password="$(
+        od -An -N24 -tx1 /dev/urandom |
+            tr -d ' \n'
+    )"
+
+    if [ "${#rpc_password}" -ne 48 ]; then
+        error "Could not generate RPC password"
+        exit 1
+    fi
+}
+
+write_wallet_password()
+{
+    if ((wallet_has_password)); then
+        printf '%s\n' "$wallet_password" >"$WALLET_PASSWORD_FILE"
+        chmod 600 "$WALLET_PASSWORD_FILE"
+        return
+    fi
+
+    rm -f "$WALLET_PASSWORD_FILE"
+}
+
+write_rpc_password()
+{
+    printf '%s\n' "$rpc_password" >"$RPC_PASSWORD_FILE"
+    chmod 600 "$RPC_PASSWORD_FILE"
+}
+
+write_monerod_config()
+{
+    {
+        case "$network" in
+            stagenet)
+                echo "stagenet=1"
+                ;;
+            testnet)
+                echo "testnet=1"
+                ;;
+        esac
+
+        echo "rpc-bind-ip=127.0.0.1"
+    } >"$MONEROD_CONFIG"
+
+    chmod 600 "$MONEROD_CONFIG"
+}
+
+write_wallet_rpc_config()
+{
+    {
+        case "$network" in
+            stagenet)
+                echo "stagenet=1"
+                ;;
+            testnet)
+                echo "testnet=1"
+                ;;
+        esac
+
+        printf 'wallet-file=%s\n' "$wallet_path"
+
+        if ((wallet_has_password)); then
+            printf 'password-file=%s\n' "$WALLET_PASSWORD_FILE"
+        fi
+
+        echo "rpc-bind-ip=127.0.0.1"
+        printf 'rpc-bind-port=%s\n' "$wallet_rpc_port"
+        printf 'rpc-login=mnp:%s\n' "$rpc_password"
+        printf 'daemon-address=127.0.0.1:%s\n' "$daemon_port"
+        echo "trusted-daemon=1"
+        printf 'tx-notify=%s %%s --confirmation 1\n' "$mnp_bin"
+    } >"$WALLET_RPC_CONFIG"
+
+    chmod 600 "$WALLET_RPC_CONFIG"
+}
+
+write_mnp_config()
+{
+    cat >"$MNP_CONFIG" <<EOF
+[rpc]
+user = mnp
+password = ${rpc_password}
+host = 127.0.0.1
+port = ${wallet_rpc_port}
+
+[mnp]
+verbose = 0
+account = 0
+
+[cfg]
+workdir = ${WORKDIR}
+mode = rwx------
+pipe = rw-------
+EOF
+
+    chmod 600 "$MNP_CONFIG"
+}
+
+create_legacy_config_link()
+{
+    local answer
+
+    if [ -L "$LEGACY_MNP_CONFIG" ]; then
+        if [ "$(readlink -f "$LEGACY_MNP_CONFIG")" = "$(readlink -f "$MNP_CONFIG")" ]; then
+            ok "Legacy config link already exists"
+            return
+        fi
+
+        ln -sfn "$MNP_CONFIG" "$LEGACY_MNP_CONFIG"
+        ok "Updated legacy config link: ${LEGACY_MNP_CONFIG}"
+        return
+    fi
+
+    if [ -e "$LEGACY_MNP_CONFIG" ]; then
+        warn "Existing configuration found: ${LEGACY_MNP_CONFIG}"
+
+        read -r -p "Back up and replace it with a symlink? [y/N] " answer
+
+        case "$answer" in
+            y|Y|yes|YES)
+                mv \
+                    "$LEGACY_MNP_CONFIG" \
+                    "${LEGACY_MNP_CONFIG}.backup"
+
+                ln -s "$MNP_CONFIG" "$LEGACY_MNP_CONFIG"
+
+                ok "Previous config saved as ${LEGACY_MNP_CONFIG}.backup"
+                ok "Legacy config link created: ${LEGACY_MNP_CONFIG}"
+                ;;
+            *)
+                warn "Keeping existing ${LEGACY_MNP_CONFIG}"
+                ;;
+        esac
+
+        return
+    fi
+
+    ln -s "$MNP_CONFIG" "$LEGACY_MNP_CONFIG"
+    ok "Legacy config link created: ${LEGACY_MNP_CONFIG}"
+}
+
+print_summary()
+{
+    echo
+    echo "Configuration complete."
+    echo
+    echo "  Wallet:     ${wallet_path}"
+    echo "  Network:    ${network}"
+    echo "  Daemon RPC: 127.0.0.1:${daemon_port}"
+    echo "  Wallet RPC: 127.0.0.1:${wallet_rpc_port}"
+    echo "  Config:     ${CONFIG_DIR}"
+
+    if ((wallet_has_password)); then
+        echo "  Password:   ${WALLET_PASSWORD_FILE}"
+    else
+        echo "  Password:   none"
+    fi
+
+    echo
+    echo "  Legacy:     ${LEGACY_MNP_CONFIG} -> ${MNP_CONFIG}"
+    echo
+
+    if ((missing_runtime)); then
+        warn "Some runtime dependencies are missing"
+        echo "       start.sh will perform the strict runtime checks." >&2
+    fi
+
+    echo "No Monero process has been started."
+}
+
+main()
+{
+    case "${1:-}" in
+        "")
+            ;;
+        help|--help|-h)
+            usage
+            return
+            ;;
+        *)
+            usage >&2
+            return 1
+            ;;
+    esac
+
+    if (($# > 1)); then
+        usage >&2
+        return 1
+    fi
+
+    check_dependencies
+    create_config_dir
+    select_wallet
+    select_network
+    read_wallet_password
+    generate_rpc_password
+    write_wallet_password
+    write_rpc_password
+    write_monerod_config
+    write_wallet_rpc_config
+    write_mnp_config
+    create_legacy_config_link
+    print_summary
+}
+
+main "$@"

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/mnp"
+MNP_CONFIG="${CONFIG_DIR}/mnp.ini"
+MONEROD_CONFIG="${CONFIG_DIR}/monerod.conf"
+WALLET_RPC_CONFIG="${CONFIG_DIR}/monero-wallet-rpc.conf"
+RPC_PASSWORD_FILE="${CONFIG_DIR}/rpc.password"
+WALLET_RPC_PIDFILE="${CONFIG_DIR}/monero-wallet-rpc.pid"
+
+wallet_rpc_port=""
+wallet_rpc_pid=""
+wallet_password_file=""
+wallet_password_args=()
+
+usage()
+{
+    cat <<EOF
+Usage:
+  $0
+
+Starts monerod and monero-wallet-rpc using:
+
+  ${CONFIG_DIR}
+EOF
+}
+
+ok()
+{
+    printf '[OK] %s\n' "$1"
+}
+
+error()
+{
+    printf '[ERROR] %s\n' "$1" >&2
+}
+
+print_monero_install_help()
+{
+    cat >&2 <<'EOF'
+
+Monero CLI is required.
+
+Download the official Monero CLI from:
+
+  https://www.getmonero.org/downloads/
+
+After extracting the archive, install monerod and monero-wallet-rpc
+into /usr/local/bin:
+
+  sudo install -m 755 /path/to/monero/monerod \
+      /usr/local/bin/monerod
+
+  sudo install -m 755 /path/to/monero/monero-wallet-rpc \
+      /usr/local/bin/monero-wallet-rpc
+
+Verify afterwards:
+
+  command -v monerod
+  command -v monero-wallet-rpc
+EOF
+}
+
+require_monero()
+{
+    local missing=0
+
+    if ! command -v monerod >/dev/null 2>&1; then
+        error "monerod not found"
+        missing=1
+    fi
+
+    if ! command -v monero-wallet-rpc >/dev/null 2>&1; then
+        error "monero-wallet-rpc not found"
+        missing=1
+    fi
+
+    if ((missing)); then
+        print_monero_install_help
+        return 1
+    fi
+
+    ok "monerod: $(command -v monerod)"
+    ok "monero-wallet-rpc: $(command -v monero-wallet-rpc)"
+}
+
+require_command()
+{
+    local command_name="$1"
+
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+        error "Required command '${command_name}' not found"
+        return 1
+    fi
+
+    ok "${command_name}: $(command -v "$command_name")"
+}
+
+require_file()
+{
+    local path="$1"
+
+    if [ ! -r "$path" ]; then
+        error "Required file '${path}' not found or not readable"
+        return 1
+    fi
+
+    ok "$path"
+}
+
+check_dependencies()
+{
+    echo "Checking runtime dependencies..."
+
+    require_monero
+    require_command mnp
+    require_command ss
+
+    echo
+}
+
+configure_wallet_password()
+{
+    wallet_password_file="$(
+        awk -F= '
+            /^[[:space:]]*password-file[[:space:]]*=/ {
+                sub(/^[[:space:]]*/, "", $2)
+                sub(/[[:space:]]*$/, "", $2)
+                print $2
+                exit
+            }
+        ' "$WALLET_RPC_CONFIG"
+    )"
+
+    if [ -n "$wallet_password_file" ]; then
+        require_file "$wallet_password_file"
+        ok "Wallet password file: ${wallet_password_file}"
+        return
+    fi
+
+    wallet_password_args=(--password "")
+    ok "Wallet password: none"
+}
+
+check_configuration()
+{
+    echo "Checking configuration..."
+
+    require_file "$MNP_CONFIG"
+    require_file "$MONEROD_CONFIG"
+    require_file "$WALLET_RPC_CONFIG"
+    require_file "$RPC_PASSWORD_FILE"
+
+    configure_wallet_password
+
+    echo
+}
+
+read_wallet_rpc_port()
+{
+    wallet_rpc_port="$(
+        awk -F= '
+            /^[[:space:]]*rpc-bind-port[[:space:]]*=/ {
+                gsub(/[[:space:]]/, "", $2)
+                print $2
+                exit
+            }
+        ' "$WALLET_RPC_CONFIG"
+    )"
+
+    if ! [[ "$wallet_rpc_port" =~ ^[0-9]+$ ]] ||
+       ((wallet_rpc_port < 1 || wallet_rpc_port > 65535)); then
+        error "Invalid or missing rpc-bind-port in '${WALLET_RPC_CONFIG}'"
+        return 1
+    fi
+}
+
+get_listener_pid()
+{
+    local port="$1"
+    local listener
+
+    listener="$(
+        ss -H -ltnp "sport = :${port}" 2>/dev/null |
+            head -n1
+    )"
+
+    if [ -z "$listener" ]; then
+        return 1
+    fi
+
+    if [[ "$listener" =~ pid=([0-9]+) ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+        return
+    fi
+
+    return 2
+}
+
+get_process_name()
+{
+    local pid="$1"
+    local executable
+
+    executable="$(readlink -f "/proc/${pid}/exe" 2>/dev/null || true)"
+
+    if [ -n "$executable" ]; then
+        basename "$executable"
+        return
+    fi
+
+    printf 'unknown\n'
+}
+
+wait_for_process()
+{
+    local pid="$1"
+    local i
+
+    for ((i = 0; i < 50; i++)); do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            return
+        fi
+
+        sleep 0.1
+    done
+
+    return 1
+}
+
+wait_for_wallet_rpc()
+{
+    local i
+
+    for ((i = 0; i < 100; i++)); do
+        if get_listener_pid "$wallet_rpc_port" >/dev/null 2>&1; then
+            return
+        fi
+
+        sleep 0.1
+    done
+
+    return 1
+}
+
+stop_existing_wallet_rpc()
+{
+    local pid="$1"
+
+    echo "Stopping monero-wallet-rpc (PID ${pid})..."
+
+    kill "$pid"
+
+    if ! wait_for_process "$pid"; then
+        error "monero-wallet-rpc did not stop"
+        return 1
+    fi
+
+    rm -f "$WALLET_RPC_PIDFILE"
+
+    ok "monero-wallet-rpc stopped"
+}
+
+check_wallet_rpc_port()
+{
+    local status
+    local process_name
+    local answer
+
+    set +e
+    wallet_rpc_pid="$(get_listener_pid "$wallet_rpc_port")"
+    status=$?
+    set -e
+
+    case "$status" in
+        1)
+            return
+            ;;
+        2)
+            error "Port ${wallet_rpc_port} is in use but the process could not be identified"
+            return 1
+            ;;
+    esac
+
+    process_name="$(get_process_name "$wallet_rpc_pid")"
+
+    if [ "$process_name" != "monero-wallet-rpc" ]; then
+        error "Port ${wallet_rpc_port} is used by '${process_name}' (PID ${wallet_rpc_pid})"
+        return 1
+    fi
+
+    echo
+    echo "monero-wallet-rpc is already listening on port ${wallet_rpc_port}."
+    echo "PID: ${wallet_rpc_pid}"
+    echo
+
+    read -r -p "Restart monero-wallet-rpc? [y/N] " answer
+
+    case "$answer" in
+        y|Y|yes|YES)
+            stop_existing_wallet_rpc "$wallet_rpc_pid"
+            ;;
+        *)
+            ok "Keeping existing monero-wallet-rpc running"
+            exit 0
+            ;;
+    esac
+}
+
+start_monerod()
+{
+    if pgrep -x monerod >/dev/null 2>&1; then
+        ok "monerod is already running"
+        return
+    fi
+
+    echo "Starting monerod..."
+
+    monerod \
+        --config-file "$MONEROD_CONFIG" \
+        --detach
+
+    sleep 1
+
+    if ! pgrep -x monerod >/dev/null 2>&1; then
+        error "monerod failed to start"
+        return 1
+    fi
+
+    ok "monerod started"
+}
+
+start_wallet_rpc()
+{
+    rm -f "$WALLET_RPC_PIDFILE"
+
+    echo "Starting monero-wallet-rpc on port ${wallet_rpc_port}..."
+
+    monero-wallet-rpc \
+        --config-file "$WALLET_RPC_CONFIG" \
+        --detach \
+        --pidfile "$WALLET_RPC_PIDFILE" \
+        "${wallet_password_args[@]}"
+
+    if ! wait_for_wallet_rpc; then
+        error "monero-wallet-rpc failed to start on port ${wallet_rpc_port}"
+        return 1
+    fi
+
+    ok "monero-wallet-rpc started"
+    ok "Wallet RPC: 127.0.0.1:${wallet_rpc_port}"
+
+    if [ -r "$WALLET_RPC_PIDFILE" ]; then
+        ok "PID: $(cat "$WALLET_RPC_PIDFILE")"
+    fi
+}
+
+main()
+{
+    case "${1:-}" in
+        "")
+            ;;
+        help|--help|-h)
+            usage
+            return
+            ;;
+        *)
+            usage >&2
+            return 1
+            ;;
+    esac
+
+    if (($# > 1)); then
+        usage >&2
+        return 1
+    fi
+
+    check_dependencies
+    check_configuration
+    read_wallet_rpc_port
+    check_wallet_rpc_port
+    start_monerod
+    start_wallet_rpc
+}
+
+main "$@"

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/mnp"
+WALLET_RPC_CONFIG="${CONFIG_DIR}/monero-wallet-rpc.conf"
+WALLET_RPC_PIDFILE="${CONFIG_DIR}/monero-wallet-rpc.pid"
+
+wallet_rpc_port=""
+
+usage()
+{
+    cat <<EOF
+Usage:
+  $0 [--all]
+
+Options:
+  --all       Stop monero-wallet-rpc and monerod
+  -h, --help  Show this help
+
+Without --all only the configured monero-wallet-rpc is stopped.
+EOF
+}
+
+ok()
+{
+    printf '[OK] %s\n' "$1"
+}
+
+warn()
+{
+    printf '[WARN] %s\n' "$1" >&2
+}
+
+error()
+{
+    printf '[ERROR] %s\n' "$1" >&2
+}
+
+require_command()
+{
+    local command_name="$1"
+
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+        error "Required command '${command_name}' not found"
+        return 1
+    fi
+}
+
+read_wallet_rpc_port()
+{
+    if [ ! -r "$WALLET_RPC_CONFIG" ]; then
+        error "Required file '${WALLET_RPC_CONFIG}' not found or not readable"
+        return 1
+    fi
+
+    wallet_rpc_port="$(
+        awk -F= '
+            /^[[:space:]]*rpc-bind-port[[:space:]]*=/ {
+                gsub(/[[:space:]]/, "", $2)
+                print $2
+                exit
+            }
+        ' "$WALLET_RPC_CONFIG"
+    )"
+
+    if ! [[ "$wallet_rpc_port" =~ ^[0-9]+$ ]] ||
+       ((wallet_rpc_port < 1 || wallet_rpc_port > 65535)); then
+        error "Invalid or missing rpc-bind-port in '${WALLET_RPC_CONFIG}'"
+        return 1
+    fi
+}
+
+get_process_name()
+{
+    local pid="$1"
+    local executable
+
+    executable="$(readlink -f "/proc/${pid}/exe" 2>/dev/null || true)"
+
+    if [ -n "$executable" ]; then
+        basename "$executable"
+        return
+    fi
+
+    printf 'unknown\n'
+}
+
+wait_for_process()
+{
+    local pid="$1"
+    local i
+
+    for ((i = 0; i < 50; i++)); do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+
+        sleep 0.1
+    done
+
+    return 1
+}
+
+stop_pid()
+{
+    local pid="$1"
+    local process_name
+
+    if ! kill -0 "$pid" 2>/dev/null; then
+        return 1
+    fi
+
+    process_name="$(get_process_name "$pid")"
+
+    if [ "$process_name" != "monero-wallet-rpc" ]; then
+        error "PID ${pid} belongs to '${process_name}', not monero-wallet-rpc"
+        return 2
+    fi
+
+    echo "Stopping monero-wallet-rpc (PID ${pid})..."
+
+    kill "$pid"
+
+    if ! wait_for_process "$pid"; then
+        error "monero-wallet-rpc did not stop"
+        return 1
+    fi
+
+    rm -f "$WALLET_RPC_PIDFILE"
+
+    ok "monero-wallet-rpc stopped"
+}
+
+stop_wallet_rpc_from_pidfile()
+{
+    local pid
+    local status
+
+    if [ ! -r "$WALLET_RPC_PIDFILE" ]; then
+        return 1
+    fi
+
+    pid="$(cat "$WALLET_RPC_PIDFILE")"
+
+    if ! [[ "$pid" =~ ^[0-9]+$ ]]; then
+        warn "Invalid PID file: ${WALLET_RPC_PIDFILE}"
+        rm -f "$WALLET_RPC_PIDFILE"
+        return 1
+    fi
+
+    set +e
+    stop_pid "$pid"
+    status=$?
+    set -e
+
+    case "$status" in
+        0)
+            return 0
+            ;;
+        1)
+            warn "PID file is stale"
+            rm -f "$WALLET_RPC_PIDFILE"
+            return 1
+            ;;
+        2)
+            return 2
+            ;;
+    esac
+}
+
+get_listener_pid()
+{
+    local port="$1"
+    local listener
+
+    listener="$(
+        ss -H -ltnp "sport = :${port}" 2>/dev/null |
+            head -n1
+    )"
+
+    if [ -z "$listener" ]; then
+        return 1
+    fi
+
+    if [[ "$listener" =~ pid=([0-9]+) ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+        return 0
+    fi
+
+    return 2
+}
+
+stop_wallet_rpc_from_port()
+{
+    local pid
+    local status
+    local process_name
+
+    set +e
+    pid="$(get_listener_pid "$wallet_rpc_port")"
+    status=$?
+    set -e
+
+    case "$status" in
+        1)
+            ok "monero-wallet-rpc is not running on port ${wallet_rpc_port}"
+            return 0
+            ;;
+        2)
+            error "Port ${wallet_rpc_port} is in use but the process could not be identified"
+            return 1
+            ;;
+    esac
+
+    process_name="$(get_process_name "$pid")"
+
+    if [ "$process_name" != "monero-wallet-rpc" ]; then
+        error "Port ${wallet_rpc_port} is used by '${process_name}' (PID ${pid})"
+        return 1
+    fi
+
+    stop_pid "$pid"
+}
+
+stop_wallet_rpc()
+{
+    local status
+
+    set +e
+    stop_wallet_rpc_from_pidfile
+    status=$?
+    set -e
+
+    case "$status" in
+        0)
+            return
+            ;;
+        2)
+            return 1
+            ;;
+    esac
+
+    stop_wallet_rpc_from_port
+}
+
+stop_monerod()
+{
+    local -a pids
+    local pid
+
+    mapfile -t pids < <(
+        pgrep -u "$UID" -x monerod 2>/dev/null || true
+    )
+
+    if ((${#pids[@]} == 0)); then
+        ok "monerod is not running"
+        return
+    fi
+
+    echo "Stopping monerod..."
+
+    kill "${pids[@]}"
+
+    for pid in "${pids[@]}"; do
+        if ! wait_for_process "$pid"; then
+            error "monerod PID ${pid} did not stop"
+            return 1
+        fi
+    done
+
+    ok "monerod stopped"
+}
+
+main()
+{
+    local stop_all=0
+
+    case "${1:-}" in
+        "")
+            ;;
+        --all)
+            stop_all=1
+            ;;
+        help|--help|-h)
+            usage
+            return
+            ;;
+        *)
+            usage >&2
+            return 1
+            ;;
+    esac
+
+    if (($# > 1)); then
+        usage >&2
+        return 1
+    fi
+
+    require_command ss
+    read_wallet_rpc_port
+    stop_wallet_rpc
+
+    if ((stop_all)); then
+        stop_monerod
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
- Add setup.sh for wallet and RPC configuration
- Add start.sh and stop.sh for Monero runtime management
- Store configuration under ~/.config/mnp
- Keep temporary compatibility with ~/.mnp.ini
- Remove CMake installation of .mnp.ini
- Update README setup instructions