### PR TITLE
Sign verify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ set(MNP_SOURCES
     monitor.c
     spend_proof.c
     tx_proof.c
+    sign.c
+    verify.c
     payment.c
     balance.c
     bc_height.c

--- a/globaldefs.h
+++ b/globaldefs.h
@@ -63,6 +63,9 @@ enum notify {
 #define SPEND_PROOF_CMD "check_spend_proof"
 #define TX_PROOF_CMD    "check_tx_proof"
 
+#define SIGN_CMD 	"sign"
+#define VERIFY_CMD 	"verify"
+
 #define TRANSACTION_DIR "transactions"
 
 #define PAYNULL         "0000000000000000"

--- a/main.c
+++ b/main.c
@@ -38,6 +38,8 @@
 #include "payment.h"
 #include "spend_proof.h"
 #include "tx_proof.h"
+#include "sign.h"
+#include "verify.h"
 
 typedef int (*command_handler_fn)(int argc, char **argv);
 typedef void (*command_help_fn)(FILE *stream, const char *program);
@@ -79,6 +81,18 @@ static const struct command commands[] = {
         "Verify a transaction proof",
         tx_proof_main,
         tx_proof_help,
+    },
+    {
+    "sign",
+    "Sign data with the wallet view key",
+    sign_main,
+    sign_help,
+    },
+    {
+    "verify",
+    "Verify a message signature",
+    verify_main,
+    verify_help,
     },
     {
         "balance",

--- a/rpc_call.c
+++ b/rpc_call.c
@@ -331,6 +331,14 @@ char *get_method(enum monero_rpc_method method)
         name = TX_PROOF_CMD;
         break;
 
+    case SIGN_MESSAGE:
+        name = SIGN_CMD;
+        break;
+
+    case VERIFY_MESSAGE:
+        name = VERIFY_CMD;
+        break;
+
     default:
         return NULL;
     }
@@ -543,6 +551,66 @@ static int add_rpc_parameters(cJSON *params, const struct rpc_wallet *monero_wal
         }
         break;
 
+    case SIGN_MESSAGE:
+	if (cJSON_AddStringToObject(
+            	params,
+            	"data",
+            	monero_wallet->data
+            ) == NULL) {
+            return -1;
+    	}
+
+        if (cJSON_AddNumberToObject(
+                params,
+                "account_index",
+                atoi(monero_wallet->account)
+            ) == NULL) {
+            return -1;
+        }
+
+        if (cJSON_AddNumberToObject(
+                params,
+                "address_index",
+                monero_wallet->idx
+            ) == NULL) {
+            return -1;
+        }
+
+        if (cJSON_AddStringToObject(
+                params,
+                "signature_type",
+                "view"
+            ) == NULL) {
+            return -1;
+        }
+        break;
+
+    case VERIFY_MESSAGE:
+        if (cJSON_AddStringToObject(
+                params,
+                "data",
+                monero_wallet->data
+            ) == NULL) {
+            return -1;
+        }
+
+        if (cJSON_AddStringToObject(
+                params,
+                "address",
+                monero_wallet->saddr
+            ) == NULL) {
+            return -1;
+        }
+
+        if (cJSON_AddStringToObject(
+                params,
+                "signature",
+                monero_wallet->signature
+            ) == NULL) {
+            return -1;
+        }
+        break;
+
     default:
         return -1;
     }
@@ -550,7 +618,7 @@ static int add_rpc_parameters(cJSON *params, const struct rpc_wallet *monero_wal
     return 0;
 }
 
-/**
+/**
  * Adds a single subaddress index to an RPC parameter object.
  *
  * @param params A pointer to the JSON object receiving the address_index array.

--- a/rpc_call.h
+++ b/rpc_call.h
@@ -15,6 +15,8 @@ enum monero_rpc_method {
     SPLIT_IADDR,
     CHECK_SPEND_PROOF,
     CHECK_TX_PROOF,
+    SIGN_MESSAGE,
+    VERIFY_MESSAGE,
     END_RPC_SIZE
 };
 
@@ -43,6 +45,8 @@ struct rpc_wallet {
        char *message;
        char *signature;
        char *proof;
+       /*mnp sign/verify */
+       char *data;
        /* general */
        int   idx;
        cJSON *reply;

--- a/sign.c
+++ b/sign.c
@@ -1,0 +1,574 @@
+#include "sign.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <pwd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "cjson/cJSON.h"
+#include "globaldefs.h"
+#include "inih/ini.h"
+#include "rpc_call.h"
+
+struct sign_args {
+    const char *message_argument;
+    int subaddress_index;
+};
+
+static char *duplicate_string(const char *value, size_t maximum);
+static int config_handler(void *user, const char *section, const char *name, const char *value);
+static char *get_config_path(void);
+static void free_config(struct Config *config);
+static int parse_nonnegative_int(const char *value, int *result);
+static int parse_arguments(int argc, char **argv, struct sign_args *args);
+static char *read_stdin(void);
+static char *get_message(const struct sign_args *args);
+static int init_wallet(struct rpc_wallet *wallet, const struct Config *config, int subaddress_index);
+static void free_wallet(struct rpc_wallet *wallet);
+static cJSON *get_result(const struct rpc_wallet *wallet);
+static char *get_signature(const struct rpc_wallet *wallet);
+
+/**
+ * Signs arbitrary data with the configured Monero wallet view key.
+ *
+ * The data may be supplied as a positional argument or through standard input.
+ * Exactly one trailing LF is removed from standard input.
+ *
+ * @param argc The number of command-line arguments.
+ * @param argv The command-line argument vector.
+ * @return EXIT_SUCCESS on success, or EXIT_FAILURE on error.
+ */
+int sign_main(int argc, char **argv)
+{
+    struct sign_args args = {0};
+    struct Config config = {0};
+    struct rpc_wallet wallet = {0};
+    char *config_path = NULL;
+    char *message = NULL;
+    char *signature = NULL;
+    int result = EXIT_FAILURE;
+
+    if (parse_arguments(argc, argv, &args) == -1) {
+        fprintf(
+            stderr,
+            "Try 'mnp sign help' for usage.\n"
+        );
+        return EXIT_FAILURE;
+    }
+
+    message = get_message(&args);
+
+    if (message == NULL) {
+        fprintf(stderr, "mnp sign: message is required\n");
+        goto done;
+    }
+
+    config_path = get_config_path();
+
+    if (config_path == NULL) {
+        fprintf(stderr, "mnp sign: cannot determine configuration path\n");
+        goto done;
+    }
+
+    if (ini_parse(config_path, config_handler, &config) < 0) {
+        fprintf(
+            stderr,
+            "mnp sign: cannot load configuration '%s'\n",
+            config_path
+        );
+        goto done;
+    }
+
+    if (init_wallet(
+            &wallet,
+            &config,
+            args.subaddress_index
+        ) == -1) {
+        fprintf(stderr, "mnp sign: incomplete RPC configuration\n");
+        goto done;
+    }
+
+    wallet.data = duplicate_string(message, MAX_DATA_SIZE);
+
+    if (wallet.data == NULL) {
+        fprintf(stderr, "mnp sign: message is too long\n");
+        goto done;
+    }
+
+    if (rpc_call(&wallet) < 0) {
+        fprintf(
+            stderr,
+            "mnp sign: could not connect to host %s:%s\n",
+            wallet.host,
+            wallet.port
+        );
+        goto done;
+    }
+
+    signature = get_signature(&wallet);
+
+    if (signature == NULL) {
+        fprintf(stderr, "mnp sign: invalid wallet RPC response\n");
+        goto done;
+    }
+
+    fprintf(stdout, "%s\n", signature);
+    result = EXIT_SUCCESS;
+
+done:
+    free(signature);
+    free(message);
+    free(config_path);
+    free_wallet(&wallet);
+    free_config(&config);
+
+    return result;
+}
+
+/**
+ * Prints usage information for the sign command.
+ *
+ * @param stream The output stream receiving the help text.
+ * @param program The program name used in usage examples.
+ */
+void sign_help(FILE *stream, const char *program)
+{
+    fprintf(
+        stream,
+        "Usage:\n"
+        "  %s sign [--subaddr INDEX] MESSAGE\n"
+        "  echo MESSAGE | %s sign [--subaddr INDEX]\n"
+        "\n"
+        "Sign arbitrary data using the wallet view key.\n"
+        "\n"
+        "Options:\n"
+        "  --subaddr INDEX\n"
+        "      Sign using the specified subaddress index.\n"
+        "      The configured account is used.\n"
+        "\n"
+        "Input:\n"
+        "  If MESSAGE is omitted, data is read from stdin.\n"
+        "  Exactly one trailing LF is removed from stdin.\n",
+        program,
+        program
+    );
+}
+
+/**
+ * Duplicates a string while enforcing a maximum accepted length.
+ *
+ * @param value The string to duplicate.
+ * @param maximum The maximum accepted string length.
+ * @return A newly allocated string, or NULL on failure.
+ */
+static char *duplicate_string(const char *value, size_t maximum)
+{
+    size_t length;
+    char *copy;
+
+    if (value == NULL) {
+        return NULL;
+    }
+
+    length = strnlen(value, maximum + 1);
+
+    if (length > maximum) {
+        return NULL;
+    }
+
+    copy = malloc(length + 1);
+
+    if (copy == NULL) {
+        return NULL;
+    }
+
+    memcpy(copy, value, length);
+    copy[length] = '\0';
+
+    return copy;
+}
+
+/**
+ * Parses RPC and account configuration values.
+ *
+ * @param user A pointer to the Config structure.
+ * @param section The configuration section.
+ * @param name The configuration key.
+ * @param value The configuration value.
+ * @return 1 if handled, or 0 otherwise.
+ */
+static int config_handler(void *user, const char *section, const char *name, const char *value)
+{
+    struct Config *config = user;
+
+#define MATCH(s, n) \
+    (strcmp(section, (s)) == 0 && strcmp(name, (n)) == 0)
+
+    if (MATCH("rpc", "user")) {
+        config->rpc_user = duplicate_string(value, MAX_DATA_SIZE);
+    } else if (MATCH("rpc", "password")) {
+        config->rpc_password = duplicate_string(value, MAX_DATA_SIZE);
+    } else if (MATCH("rpc", "host")) {
+        config->rpc_host = duplicate_string(value, MAX_DATA_SIZE);
+    } else if (MATCH("rpc", "port")) {
+        config->rpc_port = duplicate_string(value, MAX_DATA_SIZE);
+    } else if (MATCH("mnp", "account")) {
+        config->mnp_account = duplicate_string(value, MAX_DATA_SIZE);
+    } else {
+        return 0;
+    }
+
+#undef MATCH
+
+    return 1;
+}
+
+/**
+ * Builds the path to the mnp configuration file.
+ *
+ * @return A newly allocated path, or NULL on failure.
+ */
+static char *get_config_path(void)
+{
+    const char *home;
+    const struct passwd *entry;
+    size_t length;
+    char *path;
+
+    home = getenv("HOME");
+
+    if (home == NULL) {
+        entry = getpwuid(getuid());
+
+        if (entry == NULL || entry->pw_dir == NULL) {
+            return NULL;
+        }
+
+        home = entry->pw_dir;
+    }
+
+    length = strlen(home) + 1 + strlen(CONFIG_FILE) + 1;
+    path = malloc(length);
+
+    if (path == NULL) {
+        return NULL;
+    }
+
+    if (snprintf(path, length, "%s/%s", home, CONFIG_FILE) < 0) {
+        free(path);
+        return NULL;
+    }
+
+    return path;
+}
+
+/**
+ * Releases dynamically allocated configuration fields.
+ *
+ * @param config A pointer to the Config structure.
+ */
+static void free_config(struct Config *config)
+{
+    if (config == NULL) {
+        return;
+    }
+
+    free((void *)config->rpc_user);
+    free((void *)config->rpc_password);
+    free((void *)config->rpc_host);
+    free((void *)config->rpc_port);
+    free((void *)config->mnp_account);
+}
+
+/**
+ * Parses a non-negative integer.
+ *
+ * @param value The numeric string.
+ * @param result A pointer receiving the parsed value.
+ * @return 0 on success, or -1 on failure.
+ */
+static int parse_nonnegative_int(const char *value, int *result)
+{
+    char *end = NULL;
+    long parsed;
+
+    if (value == NULL || *value == '\0' || result == NULL) {
+        return -1;
+    }
+
+    errno = 0;
+    parsed = strtol(value, &end, 10);
+
+    if (errno == ERANGE ||
+        end == value ||
+        *end != '\0' ||
+        parsed < 0 ||
+        parsed > INT_MAX) {
+        return -1;
+    }
+
+    *result = (int)parsed;
+
+    return 0;
+}
+
+/**
+ * Parses sign command arguments.
+ *
+ * @param argc The number of arguments.
+ * @param argv The argument vector.
+ * @param args A pointer receiving parsed arguments.
+ * @return 0 on success, or -1 on invalid arguments.
+ */
+static int parse_arguments(int argc, char **argv, struct sign_args *args)
+{
+    int i;
+
+    if (args == NULL) {
+        return -1;
+    }
+
+    args->message_argument = NULL;
+    args->subaddress_index = 0;
+
+    for (i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "help") == 0 ||
+            strcmp(argv[i], "--help") == 0 ||
+            strcmp(argv[i], "-h") == 0) {
+            sign_help(stdout, argv[0]);
+            exit(EXIT_SUCCESS);
+        }
+
+        if (strcmp(argv[i], "--subaddr") == 0) {
+            if (++i >= argc ||
+                parse_nonnegative_int(
+                    argv[i],
+                    &args->subaddress_index
+                ) == -1) {
+                fprintf(stderr, "mnp sign: invalid subaddress index\n");
+                return -1;
+            }
+
+            continue;
+        }
+
+        if (args->message_argument != NULL) {
+            fprintf(stderr, "mnp sign: too many arguments\n");
+            return -1;
+        }
+
+        args->message_argument = argv[i];
+    }
+
+    return 0;
+}
+
+/**
+ * Reads all data from stdin and removes exactly one trailing LF.
+ *
+ * @return A newly allocated string, or NULL on failure.
+ */
+static char *read_stdin(void)
+{
+    char *buffer = NULL;
+    size_t length = 0;
+    size_t capacity = 0;
+    int character;
+
+    while ((character = fgetc(stdin)) != EOF) {
+        char *resized;
+
+        if (length + 1 >= capacity) {
+            size_t new_capacity = capacity == 0 ? 256 : capacity * 2;
+
+            if (new_capacity > MAX_DATA_SIZE + 1) {
+                new_capacity = MAX_DATA_SIZE + 1;
+            }
+
+            if (new_capacity <= capacity) {
+                free(buffer);
+                return NULL;
+            }
+
+            resized = realloc(buffer, new_capacity);
+
+            if (resized == NULL) {
+                free(buffer);
+                return NULL;
+            }
+
+            buffer = resized;
+            capacity = new_capacity;
+        }
+
+        if (length >= MAX_DATA_SIZE) {
+            free(buffer);
+            return NULL;
+        }
+
+        buffer[length++] = (char)character;
+    }
+
+    if (ferror(stdin)) {
+        free(buffer);
+        return NULL;
+    }
+
+    if (buffer == NULL) {
+        return NULL;
+    }
+
+    if (length > 0 && buffer[length - 1] == '\n') {
+        --length;
+    }
+
+    buffer[length] = '\0';
+
+    return buffer;
+}
+
+/**
+ * Obtains the message from an argument or stdin.
+ *
+ * @param args Parsed sign arguments.
+ * @return A newly allocated message, or NULL on failure.
+ */
+static char *get_message(const struct sign_args *args)
+{
+    if (args->message_argument != NULL) {
+        return duplicate_string(
+            args->message_argument,
+            MAX_DATA_SIZE
+        );
+    }
+
+    if (isatty(STDIN_FILENO)) {
+        return NULL;
+    }
+
+    return read_stdin();
+}
+
+/**
+ * Initializes a wallet RPC request for signing.
+ *
+ * @param wallet A pointer to the wallet structure.
+ * @param config A pointer to the loaded configuration.
+ * @param subaddress_index The address index to use.
+ * @return 0 on success, or -1 on failure.
+ */
+static int init_wallet(struct rpc_wallet *wallet, const struct Config *config, int subaddress_index)
+{
+    if (wallet == NULL ||
+        config == NULL ||
+        config->rpc_host == NULL ||
+        config->rpc_port == NULL ||
+        config->rpc_user == NULL ||
+        config->rpc_password == NULL) {
+        return -1;
+    }
+
+    memset(wallet, 0, sizeof(*wallet));
+
+    wallet->monero_rpc_method = SIGN_MESSAGE;
+    wallet->host = duplicate_string(config->rpc_host, MAX_DATA_SIZE);
+    wallet->port = duplicate_string(config->rpc_port, MAX_DATA_SIZE);
+    wallet->user = duplicate_string(config->rpc_user, MAX_DATA_SIZE);
+    wallet->pwd = duplicate_string(config->rpc_password, MAX_DATA_SIZE);
+    wallet->account = duplicate_string(
+        config->mnp_account != NULL ? config->mnp_account : "0",
+        MAX_DATA_SIZE
+    );
+    wallet->idx = subaddress_index;
+
+    if (wallet->host == NULL ||
+        wallet->port == NULL ||
+        wallet->user == NULL ||
+        wallet->pwd == NULL ||
+        wallet->account == NULL) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * Releases fields allocated for a wallet request.
+ *
+ * @param wallet A pointer to the wallet structure.
+ */
+static void free_wallet(struct rpc_wallet *wallet)
+{
+    if (wallet == NULL) {
+        return;
+    }
+
+    free(wallet->host);
+    free(wallet->port);
+    free(wallet->user);
+    free(wallet->pwd);
+    free(wallet->account);
+    free(wallet->data);
+
+    if (wallet->reply != NULL) {
+        cJSON_Delete(wallet->reply);
+    }
+}
+
+/**
+ * Retrieves the JSON-RPC result object.
+ *
+ * @param wallet A pointer to the wallet structure.
+ * @return The result object, or NULL if absent or invalid.
+ */
+static cJSON *get_result(const struct rpc_wallet *wallet)
+{
+    cJSON *result;
+
+    if (wallet == NULL || wallet->reply == NULL) {
+        return NULL;
+    }
+
+    result = cJSON_GetObjectItem(wallet->reply, "result");
+
+    if (result == NULL || !cJSON_IsObject(result)) {
+        return NULL;
+    }
+
+    return result;
+}
+
+/**
+ * Extracts the signature from a sign RPC response.
+ *
+ * @param wallet A pointer to the wallet structure.
+ * @return A newly allocated signature, or NULL on failure.
+ */
+static char *get_signature(const struct rpc_wallet *wallet)
+{
+    cJSON *result;
+    cJSON *signature;
+
+    result = get_result(wallet);
+
+    if (result == NULL) {
+        return NULL;
+    }
+
+    signature = cJSON_GetObjectItem(result, "signature");
+
+    if (signature == NULL ||
+        !cJSON_IsString(signature) ||
+        signature->valuestring == NULL) {
+        return NULL;
+    }
+
+    return duplicate_string(
+        signature->valuestring,
+        MAX_DATA_SIZE
+    );
+}
+

--- a/sign.c
+++ b/sign.c
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2026 d4ndo@proton.me
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #include "sign.h"
 
 #include <errno.h>

--- a/sign.h
+++ b/sign.h
@@ -1,0 +1,10 @@
+#ifndef MNP_SIGN_H
+#define MNP_SIGN_H
+
+#include <stdio.h>
+
+int sign_main(int argc, char **argv);
+void sign_help(FILE *stream, const char *program);
+
+#endif
+

--- a/validate.c
+++ b/validate.c
@@ -24,35 +24,34 @@
  */
 
 #include <assert.h>
+#include <ctype.h>
+#include <errno.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
-#include <stdint.h>
-#include <errno.h>
+
 #include "globaldefs.h"
 
+static int val_base58(const char *value);
 
-/*
+/**
  * Validates hexadecimal input of specified size.
- * Checks for valid payment ID or transaction ID.
  *
- * Parameters:
- *   hex: Pointer to the hexadecimal input string
- *   size: Size of the input string to be validated
- *
- * Returns:
- *   -1 if input is invalid
- *    0 if input is valid
+ * @param hex Pointer to the hexadecimal input string.
+ * @param size Expected input size.
+ * @return 0 if valid, or -1 otherwise.
  */
-int val_hex_input(const char *hex, const unsigned int size) {
+int val_hex_input(const char *hex, const unsigned int size)
+{
+    unsigned int i;
 
-    if (strlen(hex) != size) {
+    if (hex == NULL || strlen(hex) != size) {
         return -1;
     }
 
-    for (int i = 0; i < size; i++) {
-        if (!isxdigit(hex[i])) {
+    for (i = 0; i < size; i++) {
+        if (!isxdigit((unsigned char)hex[i])) {
             return -1;
         }
     }
@@ -60,21 +59,107 @@ int val_hex_input(const char *hex, const unsigned int size) {
     return 0;
 }
 
-
-/*
- * Validates an input string to ensure it contains only digits.
+/**
+ * Validates an atomic amount.
  *
- * Parameters:
- *   amount: Pointer to the input string to be validated
- *
- * Returns:
- *   -1 if input contains non-digit characters
- *    0 if input contains only digits
+ * @param amount Pointer to the amount string.
+ * @return 0 if valid, or -1 otherwise.
  */
-int val_amount(const char *amount) {
+int val_amount(const char *amount)
+{
+    size_t i;
 
-    for (int i = 0; i < strlen(amount); i++) {
-        if (!isdigit(amount[i])) {
+    if (amount == NULL || *amount == '\0') {
+        return -1;
+    }
+
+    for (i = 0; i < strlen(amount); i++) {
+        if (!isdigit((unsigned char)amount[i])) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * Performs a lightweight offline validation of a Monero address.
+ *
+ * This validates only length and Base58 syntax. It does not verify
+ * network type, checksum, or cryptographic validity.
+ *
+ * @param address Pointer to the address string.
+ * @return 0 if plausible, or -1 otherwise.
+ */
+int val_address(const char *address)
+{
+    size_t length;
+
+    if (address == NULL) {
+        return -1;
+    }
+
+    length = strlen(address);
+
+    if (length != 95 && length != 106) {
+        return -1;
+    }
+
+    return val_base58(address);
+}
+
+/**
+ * Performs a lightweight offline validation of a Monero message signature.
+ *
+ * Cryptographic validity is checked later by monero-wallet-rpc verify.
+ *
+ * @param signature Pointer to the signature string.
+ * @return 0 if plausible, or -1 otherwise.
+ */
+int val_signature(const char *signature)
+{
+    size_t length;
+
+    if (signature == NULL) {
+        return -1;
+    }
+
+    length = strlen(signature);
+
+    if (length < 6) {
+        return -1;
+    }
+
+    if (strncmp(signature, "SigV", 4) != 0) {
+        return -1;
+    }
+
+    if (!isdigit((unsigned char)signature[4])) {
+        return -1;
+    }
+
+    return val_base58(signature + 5);
+}
+
+/**
+ * Validates characters against the Monero Base58 alphabet.
+ *
+ * @param value Pointer to the string to validate.
+ * @return 0 if valid, or -1 otherwise.
+ */
+static int val_base58(const char *value)
+{
+    static const char alphabet[] =
+        "123456789ABCDEFGHJKLMNPQRSTUVWXYZ"
+        "abcdefghijkmnopqrstuvwxyz";
+    size_t i;
+
+    if (value == NULL || *value == '\0') {
+        return -1;
+    }
+
+    for (i = 0; value[i] != '\0'; i++) {
+        if (strchr(alphabet, value[i]) == NULL) {
             return -1;
         }
     }

--- a/validate.h
+++ b/validate.h
@@ -3,5 +3,8 @@
 
 int val_hex_input(const char *hex, const unsigned int size);
 int val_amount(const char *amount);
+int val_address(const char *address);
+int val_signature(const char *signature);
 
 #endif
+

--- a/verify.c
+++ b/verify.c
@@ -1,0 +1,489 @@
+#include "verify.h"
+
+#include <pwd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "cjson/cJSON.h"
+#include "globaldefs.h"
+#include "inih/ini.h"
+#include "rpc_call.h"
+
+struct verify_args {
+    const char *address;
+    const char *signature;
+    const char *message_argument;
+};
+
+static char *duplicate_string(const char *value, size_t maximum);
+static int config_handler(void *user, const char *section, const char *name, const char *value);
+static char *get_config_path(void);
+static void free_config(struct Config *config);
+static int parse_arguments(int argc, char **argv, struct verify_args *args);
+static char *read_stdin(void);
+static char *get_message(const struct verify_args *args);
+static int init_wallet(struct rpc_wallet *wallet, const struct Config *config);
+static void free_wallet(struct rpc_wallet *wallet);
+static int signature_is_good(const struct rpc_wallet *wallet);
+
+/**
+ * Verifies a Monero message signature.
+ *
+ * The signed data may be supplied as a positional argument or through standard input.
+ * Exactly one trailing LF is removed from standard input.
+ *
+ * @param argc The number of command-line arguments.
+ * @param argv The command-line argument vector.
+ * @return EXIT_SUCCESS for a valid signature, or EXIT_FAILURE otherwise.
+ */
+int verify_main(int argc, char **argv)
+{
+    struct verify_args args = {0};
+    struct Config config = {0};
+    struct rpc_wallet wallet = {0};
+    char *config_path = NULL;
+    char *message = NULL;
+    int good;
+    int result = EXIT_FAILURE;
+
+    if (parse_arguments(argc, argv, &args) == -1) {
+        fprintf(
+            stderr,
+            "Try 'mnp verify help' for usage.\n"
+        );
+        return EXIT_FAILURE;
+    }
+
+    message = get_message(&args);
+
+    if (message == NULL) {
+        fprintf(stderr, "mnp verify: message is required\n");
+        goto done;
+    }
+
+    config_path = get_config_path();
+
+    if (config_path == NULL) {
+        fprintf(stderr, "mnp verify: cannot determine configuration path\n");
+        goto done;
+    }
+
+    if (ini_parse(config_path, config_handler, &config) < 0) {
+        fprintf(
+            stderr,
+            "mnp verify: cannot load configuration '%s'\n",
+            config_path
+        );
+        goto done;
+    }
+
+    if (init_wallet(&wallet, &config) == -1) {
+        fprintf(stderr, "mnp verify: incomplete RPC configuration\n");
+        goto done;
+    }
+
+    wallet.data = duplicate_string(message, MAX_DATA_SIZE);
+    wallet.saddr = duplicate_string(args.address, MAX_DATA_SIZE);
+    wallet.signature = duplicate_string(args.signature, MAX_DATA_SIZE);
+
+    if (wallet.data == NULL ||
+        wallet.saddr == NULL ||
+        wallet.signature == NULL) {
+        fprintf(stderr, "mnp verify: invalid input\n");
+        goto done;
+    }
+
+    if (rpc_call(&wallet) < 0) {
+        fprintf(
+            stderr,
+            "mnp verify: could not connect to host %s:%s\n",
+            wallet.host,
+            wallet.port
+        );
+        goto done;
+    }
+
+    good = signature_is_good(&wallet);
+
+    if (good == -1) {
+        fprintf(stderr, "mnp verify: invalid wallet RPC response\n");
+        goto done;
+    }
+
+    fprintf(stdout, "%s\n", good ? "true" : "false");
+
+    if (good) {
+        result = EXIT_SUCCESS;
+    }
+
+done:
+    free(message);
+    free(config_path);
+    free_wallet(&wallet);
+    free_config(&config);
+
+    return result;
+}
+
+/**
+ * Prints usage information for the verify command.
+ *
+ * @param stream The output stream receiving the help text.
+ * @param program The program name used in usage examples.
+ */
+void verify_help(FILE *stream, const char *program)
+{
+    fprintf(
+        stream,
+        "Usage:\n"
+        "  %s verify ADDRESS SIGNATURE MESSAGE\n"
+        "  echo MESSAGE | %s verify ADDRESS SIGNATURE\n"
+        "\n"
+        "Verify a Monero message signature.\n"
+        "\n"
+        "Output:\n"
+        "  true   The signature is valid.\n"
+        "  false  The signature is invalid.\n"
+        "\n"
+        "Input:\n"
+        "  If MESSAGE is omitted, data is read from stdin.\n"
+        "  Exactly one trailing LF is removed from stdin.\n",
+        program,
+        program
+    );
+}
+
+/**
+ * Duplicates a string while enforcing a maximum accepted length.
+ *
+ * @param value The string to duplicate.
+ * @param maximum The maximum accepted string length.
+ * @return A newly allocated string, or NULL on failure.
+ */
+static char *duplicate_string(const char *value, size_t maximum)
+{
+    size_t length;
+    char *copy;
+
+    if (value == NULL) {
+        return NULL;
+    }
+
+    length = strnlen(value, maximum + 1);
+
+    if (length > maximum) {
+        return NULL;
+    }
+
+    copy = malloc(length + 1);
+
+    if (copy == NULL) {
+        return NULL;
+    }
+
+    memcpy(copy, value, length);
+    copy[length] = '\0';
+
+    return copy;
+}
+
+/**
+ * Parses RPC configuration values.
+ *
+ * @param user A pointer to the Config structure.
+ * @param section The configuration section.
+ * @param name The configuration key.
+ * @param value The configuration value.
+ * @return 1 if handled, or 0 otherwise.
+ */
+static int config_handler(void *user, const char *section, const char *name, const char *value)
+{
+    struct Config *config = user;
+
+#define MATCH(s, n) \
+    (strcmp(section, (s)) == 0 && strcmp(name, (n)) == 0)
+
+    if (MATCH("rpc", "user")) {
+        config->rpc_user = duplicate_string(value, MAX_DATA_SIZE);
+    } else if (MATCH("rpc", "password")) {
+        config->rpc_password = duplicate_string(value, MAX_DATA_SIZE);
+    } else if (MATCH("rpc", "host")) {
+        config->rpc_host = duplicate_string(value, MAX_DATA_SIZE);
+    } else if (MATCH("rpc", "port")) {
+        config->rpc_port = duplicate_string(value, MAX_DATA_SIZE);
+    } else {
+        return 0;
+    }
+
+#undef MATCH
+
+    return 1;
+}
+
+/**
+ * Builds the path to the mnp configuration file.
+ *
+ * @return A newly allocated path, or NULL on failure.
+ */
+static char *get_config_path(void)
+{
+    const char *home;
+    const struct passwd *entry;
+    size_t length;
+    char *path;
+
+    home = getenv("HOME");
+
+    if (home == NULL) {
+        entry = getpwuid(getuid());
+
+        if (entry == NULL || entry->pw_dir == NULL) {
+            return NULL;
+        }
+
+        home = entry->pw_dir;
+    }
+
+    length = strlen(home) + 1 + strlen(CONFIG_FILE) + 1;
+    path = malloc(length);
+
+    if (path == NULL) {
+        return NULL;
+    }
+
+    if (snprintf(path, length, "%s/%s", home, CONFIG_FILE) < 0) {
+        free(path);
+        return NULL;
+    }
+
+    return path;
+}
+
+/**
+ * Releases dynamically allocated configuration fields.
+ *
+ * @param config A pointer to the Config structure.
+ */
+static void free_config(struct Config *config)
+{
+    if (config == NULL) {
+        return;
+    }
+
+    free((void *)config->rpc_user);
+    free((void *)config->rpc_password);
+    free((void *)config->rpc_host);
+    free((void *)config->rpc_port);
+}
+
+/**
+ * Parses verify command arguments.
+ *
+ * @param argc The number of arguments.
+ * @param argv The argument vector.
+ * @param args A pointer receiving parsed arguments.
+ * @return 0 on success, or -1 on invalid arguments.
+ */
+static int parse_arguments(int argc, char **argv, struct verify_args *args)
+{
+    if (args == NULL) {
+        return -1;
+    }
+
+    if (argc >= 2 &&
+        (strcmp(argv[1], "help") == 0 ||
+         strcmp(argv[1], "--help") == 0 ||
+         strcmp(argv[1], "-h") == 0)) {
+        verify_help(stdout, argv[0]);
+        exit(EXIT_SUCCESS);
+    }
+
+    if (argc < 3 || argc > 4) {
+        return -1;
+    }
+
+    args->address = argv[1];
+    args->signature = argv[2];
+    args->message_argument = argc == 4 ? argv[3] : NULL;
+
+    return 0;
+}
+
+/**
+ * Reads all data from stdin and removes exactly one trailing LF.
+ *
+ * @return A newly allocated string, or NULL on failure.
+ */
+static char *read_stdin(void)
+{
+    char *buffer = NULL;
+    size_t length = 0;
+    size_t capacity = 0;
+    int character;
+
+    while ((character = fgetc(stdin)) != EOF) {
+        char *resized;
+
+        if (length + 1 >= capacity) {
+            size_t new_capacity = capacity == 0 ? 256 : capacity * 2;
+
+            if (new_capacity > MAX_DATA_SIZE + 1) {
+                new_capacity = MAX_DATA_SIZE + 1;
+            }
+
+            if (new_capacity <= capacity) {
+                free(buffer);
+                return NULL;
+            }
+
+            resized = realloc(buffer, new_capacity);
+
+            if (resized == NULL) {
+                free(buffer);
+                return NULL;
+            }
+
+            buffer = resized;
+            capacity = new_capacity;
+        }
+
+        if (length >= MAX_DATA_SIZE) {
+            free(buffer);
+            return NULL;
+        }
+
+        buffer[length++] = (char)character;
+    }
+
+    if (ferror(stdin)) {
+        free(buffer);
+        return NULL;
+    }
+
+    if (buffer == NULL) {
+        return NULL;
+    }
+
+    if (length > 0 && buffer[length - 1] == '\n') {
+        --length;
+    }
+
+    buffer[length] = '\0';
+
+    return buffer;
+}
+
+/**
+ * Obtains the signed message from an argument or stdin.
+ *
+ * @param args Parsed verify arguments.
+ * @return A newly allocated message, or NULL on failure.
+ */
+static char *get_message(const struct verify_args *args)
+{
+    if (args->message_argument != NULL) {
+        return duplicate_string(
+            args->message_argument,
+            MAX_DATA_SIZE
+        );
+    }
+
+    if (isatty(STDIN_FILENO)) {
+        return NULL;
+    }
+
+    return read_stdin();
+}
+
+/**
+ * Initializes a wallet RPC request for signature verification.
+ *
+ * @param wallet A pointer to the wallet structure.
+ * @param config A pointer to the loaded configuration.
+ * @return 0 on success, or -1 on failure.
+ */
+static int init_wallet(struct rpc_wallet *wallet, const struct Config *config)
+{
+    if (wallet == NULL ||
+        config == NULL ||
+        config->rpc_host == NULL ||
+        config->rpc_port == NULL ||
+        config->rpc_user == NULL ||
+        config->rpc_password == NULL) {
+        return -1;
+    }
+
+    memset(wallet, 0, sizeof(*wallet));
+
+    wallet->monero_rpc_method = VERIFY_MESSAGE;
+    wallet->host = duplicate_string(config->rpc_host, MAX_DATA_SIZE);
+    wallet->port = duplicate_string(config->rpc_port, MAX_DATA_SIZE);
+    wallet->user = duplicate_string(config->rpc_user, MAX_DATA_SIZE);
+    wallet->pwd = duplicate_string(config->rpc_password, MAX_DATA_SIZE);
+
+    if (wallet->host == NULL ||
+        wallet->port == NULL ||
+        wallet->user == NULL ||
+        wallet->pwd == NULL) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * Releases fields allocated for a wallet request.
+ *
+ * @param wallet A pointer to the wallet structure.
+ */
+static void free_wallet(struct rpc_wallet *wallet)
+{
+    if (wallet == NULL) {
+        return;
+    }
+
+    free(wallet->host);
+    free(wallet->port);
+    free(wallet->user);
+    free(wallet->pwd);
+    free(wallet->data);
+    free(wallet->saddr);
+    free(wallet->signature);
+
+    if (wallet->reply != NULL) {
+        cJSON_Delete(wallet->reply);
+    }
+}
+
+/**
+ * Extracts the signature verification state.
+ *
+ * @param wallet A pointer to the wallet structure.
+ * @return 1 if valid, 0 if invalid, or -1 on malformed response.
+ */
+static int signature_is_good(const struct rpc_wallet *wallet)
+{
+    cJSON *result;
+    cJSON *good;
+
+    if (wallet == NULL || wallet->reply == NULL) {
+        return -1;
+    }
+
+    result = cJSON_GetObjectItem(wallet->reply, "result");
+
+    if (result == NULL || !cJSON_IsObject(result)) {
+        return -1;
+    }
+
+    good = cJSON_GetObjectItem(result, "good");
+
+    if (good == NULL || !cJSON_IsBool(good)) {
+        return -1;
+    }
+
+    return cJSON_IsTrue(good) ? 1 : 0;
+}
+

--- a/verify.c
+++ b/verify.c
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2026 d4ndo@proton.me
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #include "verify.h"
 
 #include <pwd.h>

--- a/verify.c
+++ b/verify.c
@@ -35,6 +35,7 @@
 #include "globaldefs.h"
 #include "inih/ini.h"
 #include "rpc_call.h"
+#include "validate.h"
 
 struct verify_args {
     const char *address;
@@ -78,6 +79,16 @@ int verify_main(int argc, char **argv)
             stderr,
             "Try 'mnp verify help' for usage.\n"
         );
+        return EXIT_FAILURE;
+    }
+
+    if (val_address(args.address) < 0) {
+        fprintf(stderr, "mnp verify: invalid address\n");
+        return EXIT_FAILURE;
+    }
+
+    if (val_signature(args.signature) < 0) {
+        fprintf(stderr, "mnp verify: invalid signature\n");
         return EXIT_FAILURE;
     }
 

--- a/verify.h
+++ b/verify.h
@@ -1,0 +1,9 @@
+#ifndef MNP_VERIFY_H
+#define MNP_VERIFY_H
+
+#include <stdio.h>
+
+int verify_main(int argc, char **argv);
+void verify_help(FILE *stream, const char *program);
+
+#endif


### PR DESCRIPTION
## Summary

Add message signing and verification support to `mnp`.

## Changes

* Add `mnp sign`
* Add `mnp verify`
* Use view-key signatures by default
* Support signing with a selected subaddress
* Support stdin input for both commands
* Remove exactly one trailing LF from stdin
* Add lightweight offline validation for Monero addresses and signatures
* Return `true` / `false` for verification
* Preserve script-friendly exit codes

## Examples

Sign a message:

```bash
mnp sign "hello"
```

Or through stdin:

```bash
echo "hello" | mnp sign
```

Sign a payment URI:

```bash
mnp payment new --amount 60060065 | mnp sign
```

Verify a signature:

```bash
echo "hello" | mnp verify "$ADDRESS" "$SIGNATURE"
```

Expected output:

```text
true
```

## Notes

`mnp sign` uses the wallet view key by default, which fits the recommended view-only wallet setup for `mnp`.

The offline validation is intentionally lightweight and only rejects obviously malformed addresses and signatures. Cryptographic verification is still performed by `monero-wallet-rpc`.

The stdin handling removes exactly one trailing LF so that:

```bash
mnp sign "hello"
```

and:

```bash
echo "hello" | mnp sign
```

sign the same data.
